### PR TITLE
chore: Rename package name from modpack to organization

### DIFF
--- a/src/main/java/com/morphismmc/eioadditions/AdditionsConstants.java
+++ b/src/main/java/com/morphismmc/eioadditions/AdditionsConstants.java
@@ -1,4 +1,4 @@
-package gregtechlite.eioadditions;
+package com.morphismmc.eioadditions;
 
 import crazypants.enderio.api.EIOTags;
 

--- a/src/main/java/com/morphismmc/eioadditions/EnderIOAdditions.java
+++ b/src/main/java/com/morphismmc/eioadditions/EnderIOAdditions.java
@@ -1,15 +1,15 @@
-package gregtechlite.eioadditions;
+package com.morphismmc.eioadditions;
 
 import com.enderio.core.common.util.NNList;
+import com.morphismmc.eioadditions.common.AdditionsObject;
+import com.morphismmc.eioadditions.common.config.AdditionsConfig;
+import com.morphismmc.eioadditions.common.teleport.AdditionsTravelSource;
 import crazypants.enderio.api.addon.IEnderIOAddon;
 import crazypants.enderio.api.teleport.ITravelSource;
 import crazypants.enderio.base.EnderIO;
 import crazypants.enderio.base.config.ConfigHandlerEIO;
 import crazypants.enderio.base.config.recipes.RecipeFactory;
 import crazypants.enderio.base.init.RegisterModObject;
-import gregtechlite.eioadditions.common.AdditionsObject;
-import gregtechlite.eioadditions.common.config.AdditionsConfig;
-import gregtechlite.eioadditions.common.teleport.AdditionsTravelSource;
 import info.loenwind.autoconfig.ConfigHandler;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;

--- a/src/main/java/com/morphismmc/eioadditions/common/AdditionsObject.java
+++ b/src/main/java/com/morphismmc/eioadditions/common/AdditionsObject.java
@@ -1,13 +1,13 @@
-package gregtechlite.eioadditions.common;
+package com.morphismmc.eioadditions.common;
 
 import com.enderio.core.common.util.NullHelper;
+import com.morphismmc.eioadditions.AdditionsConstants;
+import com.morphismmc.eioadditions.common.item.ItemTeleportStaff;
 import crazypants.enderio.api.IModObject;
 import crazypants.enderio.api.IModTileEntity;
 import crazypants.enderio.base.EnderIOTab;
 import crazypants.enderio.base.init.IModObjectBase;
 import crazypants.enderio.base.init.ModObjectRegistry;
-import gregtechlite.eioadditions.AdditionsConstants;
-import gregtechlite.eioadditions.common.item.ItemTeleportStaff;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;

--- a/src/main/java/com/morphismmc/eioadditions/common/config/AdditionsConfig.java
+++ b/src/main/java/com/morphismmc/eioadditions/common/config/AdditionsConfig.java
@@ -1,7 +1,7 @@
-package gregtechlite.eioadditions.common.config;
+package com.morphismmc.eioadditions.common.config;
 
+import com.morphismmc.eioadditions.AdditionsConstants;
 import crazypants.enderio.base.config.factory.ValueFactoryEIO;
-import gregtechlite.eioadditions.AdditionsConstants;
 
 public final class AdditionsConfig {
 

--- a/src/main/java/com/morphismmc/eioadditions/common/config/AdditionsTeleportConfig.java
+++ b/src/main/java/com/morphismmc/eioadditions/common/config/AdditionsTeleportConfig.java
@@ -1,4 +1,4 @@
-package gregtechlite.eioadditions.common.config;
+package com.morphismmc.eioadditions.common.config;
 
 import info.loenwind.autoconfig.factory.IValue;
 import info.loenwind.autoconfig.factory.IValueFactory;

--- a/src/main/java/com/morphismmc/eioadditions/common/item/ItemTeleportStaff.java
+++ b/src/main/java/com/morphismmc/eioadditions/common/item/ItemTeleportStaff.java
@@ -1,7 +1,8 @@
-package gregtechlite.eioadditions.common.item;
+package com.morphismmc.eioadditions.common.item;
 
 import com.enderio.core.api.client.gui.IAdvancedTooltipProvider;
 import com.enderio.core.client.handlers.SpecialTooltipHandler;
+import com.morphismmc.eioadditions.common.teleport.AdditionsTravelSource;
 import crazypants.enderio.api.IModObject;
 import crazypants.enderio.api.teleport.IItemOfTravel;
 import crazypants.enderio.base.EnderIO;
@@ -12,7 +13,6 @@ import crazypants.enderio.base.teleport.TravelController;
 import crazypants.enderio.base.teleport.TravelUtil;
 import crazypants.enderio.util.ClientUtil;
 import crazypants.enderio.util.Mods;
-import gregtechlite.eioadditions.common.teleport.AdditionsTravelSource;
 import info.loenwind.autoconfig.factory.IValue;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;

--- a/src/main/java/com/morphismmc/eioadditions/common/item/package-info.java
+++ b/src/main/java/com/morphismmc/eioadditions/common/item/package-info.java
@@ -1,7 +1,7 @@
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 @FieldsAreNonnullByDefault
-package gregtechlite.eioadditions.common.item;
+package com.morphismmc.eioadditions.common.item;
 
 import crazypants.enderio.api.annotation.FieldsAreNonnullByDefault;
 import crazypants.enderio.api.annotation.MethodsReturnNonnullByDefault;

--- a/src/main/java/com/morphismmc/eioadditions/common/teleport/AdditionsTravelSource.java
+++ b/src/main/java/com/morphismmc/eioadditions/common/teleport/AdditionsTravelSource.java
@@ -1,10 +1,10 @@
-package gregtechlite.eioadditions.common.teleport;
+package com.morphismmc.eioadditions.common.teleport;
 
 import crazypants.enderio.api.teleport.ITravelSource;
 import crazypants.enderio.base.sound.IModSound;
 import crazypants.enderio.base.sound.SoundRegistry;
-import gregtechlite.eioadditions.AdditionsConstants;
-import gregtechlite.eioadditions.common.config.AdditionsTeleportConfig;
+import com.morphismmc.eioadditions.AdditionsConstants;
+import com.morphismmc.eioadditions.common.config.AdditionsTeleportConfig;
 import net.minecraft.util.ResourceLocation;
 
 public enum AdditionsTravelSource implements ITravelSource {

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -166,7 +166,7 @@
     "description": "Additions to Ender IO",
     "version": "${version}",
     "mcversion": "${minecraft_version}",
-    "authorList": ["gateguardian"],
+    "authorList": [ "morphismmc" ],
     "parent": "enderio",
     "dependencies": [ "enderioconduits" ]
   }


### PR DESCRIPTION
This PR change the original modpack name `gregtechlite.eioadditions` to the organization name `com.morphismmc.eioadditions` for package name.